### PR TITLE
added dylib filter

### DIFF
--- a/src/main/java/au/com/rayh/DylibFileFilter.java
+++ b/src/main/java/au/com/rayh/DylibFileFilter.java
@@ -1,0 +1,13 @@
+package au.com.rayh;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.Serializable;
+
+public class DylibFileFilter implements FileFilter, Serializable {
+    public static final String EXTESION = "dylib";
+
+    public boolean accept(File pathname)  {
+        return pathname.isFile() && pathname.getName().endsWith("." + EXTESION);
+    }
+}


### PR DESCRIPTION
Removes leftover "dylib" files left by xcode compiler when building swift apps.

### Verification:
* Build the plugin by running `mvn package`, it should create an "hpi" file in `target` folder
* Install the plugin in jenkins by uploading the hpi file (requires restart)
* Build an ios swift app with it 
* Check if there are any ".dylib" files in ipa file

ping @aliok @matskiv 