### PR TITLE
Ipa cleanup

### DIFF
--- a/src/main/java/au/com/rayh/CodeSignWrapper.java
+++ b/src/main/java/au/com/rayh/CodeSignWrapper.java
@@ -7,6 +7,8 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
 import jenkins.tasks.SimpleBuildStep;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 
 
 import javax.inject.Inject;
@@ -258,9 +260,16 @@ public class CodeSignWrapper extends Builder implements SimpleBuildStep {
     public void createIpa(Launcher launcher, TaskListener listener, String dest) throws IOException, InterruptedException {
         FilePath payloadFolder = this.binaryPath.getParent().child("Payload");
         FilePath appFolder = payloadFolder.child(this.binaryPath.getName());
+        String destFileName = StringUtils.substringAfterLast(dest, "/");
 
         if (payloadFolder.exists()) {
+            listener.getLogger().println("Removing previous Payload folder to generate a new one");
             payloadFolder.deleteRecursive();
+        }
+
+        if (this.binaryPath.exists()) {
+            listener.getLogger().println("Removing previous artifact to generate a new one: " + destFileName + ".ipa");
+            this.binaryPath.deleteRecursive();
         }
 
         payloadFolder.mkdirs();

--- a/src/main/java/au/com/rayh/CodeSignWrapper.java
+++ b/src/main/java/au/com/rayh/CodeSignWrapper.java
@@ -253,16 +253,17 @@ public class CodeSignWrapper extends Builder implements SimpleBuildStep {
     public void createIpa(Launcher launcher, TaskListener listener, String dest) throws IOException, InterruptedException {
         FilePath payloadFolder = this.binaryPath.getParent().child("Payload");
         FilePath appFolder = payloadFolder.child(this.binaryPath.getName());
-        String destFileName = StringUtils.substringAfterLast(dest, "/");
+        String destFileName = StringUtils.substringAfterLast(dest, "/") + ".ipa";
+        FilePath ipaPath = binaryPath.getParent().child(destFileName);
 
         if (payloadFolder.exists()) {
             runner.logMessage("Removing previous Payload folder to generate a new one");
             payloadFolder.deleteRecursive();
         }
 
-        if (this.binaryPath.exists()) {
-            runner.logMessage("Removing previous artifact to generate a new one: " + destFileName + ".ipa");
-            this.binaryPath.deleteRecursive();
+        if (ipaPath.exists()) {
+            runner.logMessage("Removing previous artifact to generate a new one: " + destFileName);
+            ipaPath.deleteRecursive();
         }
 
         payloadFolder.mkdirs();

--- a/src/main/java/au/com/rayh/LauncherUtility.java
+++ b/src/main/java/au/com/rayh/LauncherUtility.java
@@ -10,6 +10,7 @@ import hudson.util.ArgumentListBuilder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 
 /**
  * Created by lrossett on 7/13/17.
@@ -60,6 +61,15 @@ public class LauncherUtility {
     public void bootstrap(Launcher launcher, TaskListener listener) {
         this.launcher = launcher;
         this.listener = listener;
+    }
+
+    public PrintStream getLogger() {
+        return listener.getLogger();
+    }
+
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
+    public void logMessage(String message) {
+        getLogger().println("[Logger] " + message);
     }
 
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")

--- a/src/main/java/au/com/rayh/XCodeBuilder.java
+++ b/src/main/java/au/com/rayh/XCodeBuilder.java
@@ -208,6 +208,8 @@ public class XCodeBuilder extends Builder implements SimpleBuildStep {
 
     public boolean shouldCodeSign;
 
+    public boolean jobStatus;
+
     private String flags;
 
     private EnvVars env;
@@ -297,13 +299,17 @@ public class XCodeBuilder extends Builder implements SimpleBuildStep {
     @Override
     public void perform(Run<?, ?> build, FilePath filePath, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
 		EnvVars env = this.env != null ? this.env :  build.getEnvironment(listener);
-        _perform(build, filePath, launcher, env, listener);
+        boolean res = _perform(build, filePath, launcher, env, listener);
+        jobStatus = res;
     }
 
     @Override
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         EnvVars env = this.env != null ? this.env :  build.getEnvironment(listener);
-        return _perform(build, build.getWorkspace(), launcher, env, listener);
+        boolean res = _perform(build, build.getWorkspace(), launcher, env, listener);
+        jobStatus = res;
+
+        return jobStatus;
 	}
 
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")

--- a/src/main/java/au/com/rayh/XcodeBuildStep.java
+++ b/src/main/java/au/com/rayh/XcodeBuildStep.java
@@ -2,6 +2,7 @@ package au.com.rayh;
 
 import com.google.inject.Inject;
 
+import hudson.*;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
@@ -12,10 +13,6 @@ import javax.annotation.Nonnull;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
@@ -240,6 +237,10 @@ public class XcodeBuildStep extends AbstractStepImpl {
 
             builder.setEnv(env);
             builder.perform(build, workspace, launcher, listener);
+
+            if (!builder.jobStatus) {
+                throw new AbortException("Build aborted due to fatal errors.");
+            }
 
             return null;
         }


### PR DESCRIPTION
# Changes

* Removes ipa file before creating a new one.
* Using `LauncherUtility` log method to print log messages (all log messages start with `[Logger]`).

## Verification

* Generate a HPI file by running `mvn package` (it can also be tested using jenkins plugin debug mode by running `set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n && mvn hpi:run`)
* Upload the hpi file (usually located in the `target` folder) into a running jenkins instance and trigger an ios build, the following log message/string should appear: `[Logger] Removing previous artifact to generate a new one: something.ipa`
