### PR TITLE
added pipeline dependency for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,8 @@
       <version>1.58</version>
       <optional>true</optional>
     </dependency>
+
+		<!-- test dependencies -->
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
@@ -122,6 +124,18 @@
           <version>${powermock.version}</version>
           <scope>test</scope>
       </dependency>
+	  <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+		<dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
Adds required plugins (testing only) to enable pipeline jobs.

Running the following command should run jenkins in debug mode with enabled pipeline job:
```
mvn clean install dependency:copy-dependencies
set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n && mvn hpi:run
```
